### PR TITLE
fix commonjs version to 11.0.2

### DIFF
--- a/template/web/package.json
+++ b/template/web/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "@movingbrands/svelte-portable-text": "0.0.7",
-    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.2.0",


### PR DESCRIPTION
This is a fix for a bug in rollup - https://github.com/rollup/plugins/issues/304 which will prevent this template working. It locks the version to the last known working version. When this bug is fixed, it can be unlocked with `^` again.